### PR TITLE
Adding Tryggve use case page

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,4 @@ News pictures should be ideally be 762x507 px in size.
 
 Text is licensed under [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/).
 Source code is licensed under [MPL v2.0](../master/LICENSE).
+  

--- a/_activities/tryggve.md
+++ b/_activities/tryggve.md
@@ -21,6 +21,8 @@ projects:
 links:
   - text: Newsletters
     url: https://drive.google.com/drive/u/0/folders/1lvkw-fDmuZKPArysnN4iUMRBHCi8DIXm
+  - text: Use cases
+    url: usecase
 groups:
 ---
 Today, data saves lives. With more and better data, we can save more lives. By

--- a/_activities/tryggve.md
+++ b/_activities/tryggve.md
@@ -20,7 +20,7 @@ projects:
     url: /tryggve1
 links:
   - text: Newsletters
-    url: https://wiki.neic.no/wiki/Tryggve_News # Change to Tryggve2 newsletter folder when suitable.
+    url: https://drive.google.com/drive/u/0/folders/1lvkw-fDmuZKPArysnN4iUMRBHCi8DIXm
 groups:
 ---
 Today, data saves lives. With more and better data, we can save more lives. By

--- a/_includes/document.html
+++ b/_includes/document.html
@@ -1,0 +1,10 @@
+<section class="single-pagebanner" style="background-image: url({% include baseurl %}{{ page.banner | default:"/assets/images/api-banner.png" }});">
+</section>
+
+<section class="document">
+  <div class="container">
+    <div class="content">
+      {{ content }}
+    </div>
+  </div>
+</section>

--- a/_people/rafal-wolanin.md
+++ b/_people/rafal-wolanin.md
@@ -5,7 +5,7 @@ name: Rafal Wolanin
 home: <a href="http://www.dtu.dk/">DTU</a>
 country: DK
 photo:
-email: 
+email: rawo@dtu.dk 
 phone:
 on_contract:
 has_been_on_contract:

--- a/tryggve/usecase.md
+++ b/tryggve/usecase.md
@@ -1,0 +1,80 @@
+---
+layout: master
+include: generic
+---
+
+## Use cases
+
+
+Tryggve team wants to support researchers in taking the **secure data services** into use, and thereby to achieve results **faster and safer**. In practice, Tryggve implements specific **Use Cases** as part of the project. The Use Cases drive the development in Tryggve towards actual and concrete demands of the users. Use Cases aim to solve real-life issues in data management and/or to provide state-of-the-art research environment for sensitive research data. 
+
+The easiest way to start using secure services from Tryggve is to apply for a Tryggve use case. To submit the proposal, the project should have a research plan (involving sensitive data) and already established collaboration in the Nordics. Consult the list below on examples of what kind of support Tryggve can provide for use cases.
+
+### Tryggve offering for use cases
+
+In a nutshell, the accepted use cases will receive access to secure data processing environments; expert assistance from Tryggve; support in legal and ethical questions to make their case happen; and an opportunity to influence future developments as an early adopter. All this will be provided free of charge for the use cases for a limited time (up to a reasonable amount of disk space and computing resources).
+
+**Accessing and moving research data**
+
+* Secure data transfer, based on secure FTP
+* Data can be moved between Nordic countries or from elsewhere, for example external repositories
+
+**Support in meeting legal and ethical requirements**
+
+* Looking into specific questions, such as moving data across countries
+* Questions around merging research data from different sources
+* Professional evaluation of ethical and legal aspects
+
+**Secure data analysis platforms**
+
+* Project-based secure storage capacity 
+* Efficient and secure processing environments 
+* Tryggve offers environment, researcher brings the data
+* Variety of platforms offering flexibility to handle different use cases
+* Offering includes the following systems: TSD, Mosler, ePouta, Computerome
+
+**Share data with your colleagues**
+
+* Control over the data stays with the user
+* Access to the data can be easily given to colleagues
+
+**Software installations**
+
+* Support in moving computation where the data is
+* Guidance in installing the needed software
+
+**Access to data archives**
+
+* Support in moving data to international repositories when the analysis is done and data sets have been prepared for publication
+* Contacts to national archival services
+* Secure transfer to external repositories
+
+For more information on **the benefits, see [these slides](http://www.slideshare.net/anttipursula/tryggve-support-forresearch).**
+
+###Submit a Use Case Proposal
+
+Use Cases for Tryggve can be proposed online at any time. There are two alternatives for doing this: either provide information on your research case in an online form, or download and complete a .docx template and submit it by email to the project manager (antti.pursula@csc.fi). Please select one of the two options:
+* **[Online form](https://docs.google.com/forms/d/e/1FAIpQLScWMEzgcuhufIH2ZKsrsxCES3lI1v06pBIed5-ZL523i0Ohxg/formResponse)**.
+* **[.docx template](https://wiki.neic.no/wiki/File:Tryggve_Use_Case_form.docx)** for download
+
+###List of current use cases
+
+Please find the list the current use cases [here](https://docs.google.com/spreadsheets/d/10TT_A_ennA_dfL2f9NAyYBcZiMXFp1BHeR-j3Sfb65E/edit#gid=0)
+
+###Review process of Use Cases
+
+Please find the process description [here](https://docs.google.com/document/d/1gGpUXtdodo2OMP9gGUIvwwM2zOv_zxfFxrwY_sDZQ4Q/edit)
+
+###Links to national systems for sensitive data
+
+If a research project does not qualify as Tryggve use case, it is also possible to access the individual service providers directly. The links below help to find information on accessing the individual secure systems directly. Note that access to these services may require a service fee.
+
+* [Computerome](http://wiki.bio.dtu.dk/computerome/index.php/Computerome_-_Danish_National_Supercomputer_for_Life_Sciences#Access_to_Computerome) (Denmark)
+* [ePouta](https://research.csc.fi/pouta-user-guide) (Finland)
+* [TSD](http://www.uio.no/english/services/it/research/storage/sensitive-data/index.html) (Norway)
+* [Mosler](https://wiki.bils.se/wiki/Mosler_user_documentation) (Sweden)
+
+
+Feel free to [contact the Tryggve project](mailto:tryggve@neic.no) on any questions concerning accessing of the Nordic systems
+for sensitive data, for example if you are unsure whether to submit a use case or access separate systems directly.
+

--- a/tryggve/usecase.md
+++ b/tryggve/usecase.md
@@ -51,21 +51,21 @@ In a nutshell, the accepted use cases will receive access to secure data process
 
 For more information on **the benefits, see [these slides](http://www.slideshare.net/anttipursula/tryggve-support-forresearch).**
 
-###Submit a Use Case Proposal
+### Submit a Use Case Proposal
 
 Use Cases for Tryggve can be proposed online at any time. There are two alternatives for doing this: either provide information on your research case in an online form, or download and complete a .docx template and submit it by email to the project manager (antti.pursula@csc.fi). Please select one of the two options:
 * **[Online form](https://docs.google.com/forms/d/e/1FAIpQLScWMEzgcuhufIH2ZKsrsxCES3lI1v06pBIed5-ZL523i0Ohxg/formResponse)**.
 * **[.docx template](https://wiki.neic.no/wiki/File:Tryggve_Use_Case_form.docx)** for download
 
-###List of current use cases
+### List of current use cases
 
 Please find the list the current use cases [here](https://docs.google.com/spreadsheets/d/10TT_A_ennA_dfL2f9NAyYBcZiMXFp1BHeR-j3Sfb65E/edit#gid=0)
 
-###Review process of Use Cases
+### Review process of Use Cases
 
 Please find the process description [here](https://docs.google.com/document/d/1gGpUXtdodo2OMP9gGUIvwwM2zOv_zxfFxrwY_sDZQ4Q/edit)
 
-###Links to national systems for sensitive data
+### Links to national systems for sensitive data
 
 If a research project does not qualify as Tryggve use case, it is also possible to access the individual service providers directly. The links below help to find information on accessing the individual secure systems directly. Note that access to these services may require a service fee.
 

--- a/tryggve/usecase.md
+++ b/tryggve/usecase.md
@@ -1,6 +1,7 @@
 ---
 layout: master
 include: document
+banner: "/assets/images/sin-act-banner.png"
 ---
 
 ## Use cases

--- a/tryggve/usecase.md
+++ b/tryggve/usecase.md
@@ -1,12 +1,12 @@
 ---
 layout: master
-include: generic
+include: document
 ---
 
 ## Use cases
 
 
-Tryggve team wants to support researchers in taking the **secure data services** into use, and thereby to achieve results **faster and safer**. In practice, Tryggve implements specific **Use Cases** as part of the project. The Use Cases drive the development in Tryggve towards actual and concrete demands of the users. Use Cases aim to solve real-life issues in data management and/or to provide state-of-the-art research environment for sensitive research data. 
+Tryggve team wants to support researchers in taking the **secure data services** into use, and thereby to achieve results **faster and safer**. In practice, Tryggve implements specific **Use Cases** as part of the project. The Use Cases drive the development in Tryggve towards actual and concrete demands of the users. Use Cases aim to solve real-life issues in data management and/or to provide state-of-the-art research environment for sensitive research data.
 
 The easiest way to start using secure services from Tryggve is to apply for a Tryggve use case. To submit the proposal, the project should have a research plan (involving sensitive data) and already established collaboration in the Nordics. Consult the list below on examples of what kind of support Tryggve can provide for use cases.
 
@@ -14,37 +14,31 @@ The easiest way to start using secure services from Tryggve is to apply for a Tr
 
 In a nutshell, the accepted use cases will receive access to secure data processing environments; expert assistance from Tryggve; support in legal and ethical questions to make their case happen; and an opportunity to influence future developments as an early adopter. All this will be provided free of charge for the use cases for a limited time (up to a reasonable amount of disk space and computing resources).
 
-**Accessing and moving research data**
-
+#### Accessing and moving research data
 * Secure data transfer, based on secure FTP
 * Data can be moved between Nordic countries or from elsewhere, for example external repositories
 
-**Support in meeting legal and ethical requirements**
-
+#### Support in meeting legal and ethical requirements
 * Looking into specific questions, such as moving data across countries
 * Questions around merging research data from different sources
 * Professional evaluation of ethical and legal aspects
 
-**Secure data analysis platforms**
-
-* Project-based secure storage capacity 
-* Efficient and secure processing environments 
+#### Secure data analysis platforms
+* Project-based secure storage capacity
+* Efficient and secure processing environments
 * Tryggve offers environment, researcher brings the data
 * Variety of platforms offering flexibility to handle different use cases
 * Offering includes the following systems: TSD, Mosler, ePouta, Computerome
 
-**Share data with your colleagues**
-
+#### Share data with your colleagues
 * Control over the data stays with the user
 * Access to the data can be easily given to colleagues
 
-**Software installations**
-
+#### Software installations
 * Support in moving computation where the data is
 * Guidance in installing the needed software
 
-**Access to data archives**
-
+#### Access to data archives
 * Support in moving data to international repositories when the analysis is done and data sets have been prepared for publication
 * Contacts to national archival services
 * Secure transfer to external repositories
@@ -58,15 +52,12 @@ Use Cases for Tryggve can be proposed online at any time. There are two alternat
 * **[.docx template](https://wiki.neic.no/wiki/File:Tryggve_Use_Case_form.docx)** for download
 
 ### List of current use cases
-
 Please find the list the current use cases [here](https://docs.google.com/spreadsheets/d/10TT_A_ennA_dfL2f9NAyYBcZiMXFp1BHeR-j3Sfb65E/edit#gid=0)
 
 ### Review process of Use Cases
-
 Please find the process description [here](https://docs.google.com/document/d/1gGpUXtdodo2OMP9gGUIvwwM2zOv_zxfFxrwY_sDZQ4Q/edit)
 
 ### Links to national systems for sensitive data
-
 If a research project does not qualify as Tryggve use case, it is also possible to access the individual service providers directly. The links below help to find information on accessing the individual secure systems directly. Note that access to these services may require a service fee.
 
 * [Computerome](http://wiki.bio.dtu.dk/computerome/index.php/Computerome_-_Danish_National_Supercomputer_for_Life_Sciences#Access_to_Computerome) (Denmark)
@@ -74,7 +65,5 @@ If a research project does not qualify as Tryggve use case, it is also possible 
 * [TSD](http://www.uio.no/english/services/it/research/storage/sensitive-data/index.html) (Norway)
 * [Mosler](https://wiki.bils.se/wiki/Mosler_user_documentation) (Sweden)
 
-
 Feel free to [contact the Tryggve project](mailto:tryggve@neic.no) on any questions concerning accessing of the Nordic systems
 for sensitive data, for example if you are unsure whether to submit a use case or access separate systems directly.
-

--- a/tryggve/usecase.md
+++ b/tryggve/usecase.md
@@ -4,7 +4,7 @@ include: document
 banner: "/assets/images/sin-act-banner.png"
 ---
 
-## Use cases
+## Tryggve Use Cases
 
 
 Tryggve team wants to support researchers in taking the **secure data services** into use, and thereby to achieve results **faster and safer**. In practice, Tryggve implements specific **Use Cases** as part of the project. The Use Cases drive the development in Tryggve towards actual and concrete demands of the users. Use Cases aim to solve real-life issues in data management and/or to provide state-of-the-art research environment for sensitive research data.
@@ -68,3 +68,7 @@ If a research project does not qualify as Tryggve use case, it is also possible 
 
 Feel free to [contact the Tryggve project](mailto:tryggve@neic.no) on any questions concerning accessing of the Nordic systems
 for sensitive data, for example if you are unsure whether to submit a use case or access separate systems directly.
+
+More on **[Tryggve](https://neic.no/tryggve/)**
+
+

--- a/tryggve/usecase.md
+++ b/tryggve/usecase.md
@@ -62,7 +62,7 @@ Please find the process description [here](https://docs.google.com/document/d/1g
 If a research project does not qualify as Tryggve use case, it is also possible to access the individual service providers directly. The links below help to find information on accessing the individual secure systems directly. Note that access to these services may require a service fee.
 
 * [Computerome](http://wiki.bio.dtu.dk/computerome/index.php/Computerome_-_Danish_National_Supercomputer_for_Life_Sciences#Access_to_Computerome) (Denmark)
-* [ePouta](https://research.csc.fi/pouta-user-guide) (Finland)
+* [ePouta](https://research.csc.fi/cloud-computing) (Finland)
 * [TSD](http://www.uio.no/english/services/it/research/storage/sensitive-data/index.html) (Norway)
 * [Mosler](https://wiki.bils.se/wiki/Mosler_user_documentation) (Sweden)
 

--- a/tryggve/usecase.md
+++ b/tryggve/usecase.md
@@ -13,7 +13,7 @@ The easiest way to start using secure services from Tryggve is to apply for a Tr
 
 ### Tryggve offering for use cases
 
-In a nutshell, the accepted use cases will receive access to secure data processing environments; expert assistance from Tryggve; support in legal and ethical questions to make their case happen; and an opportunity to influence future developments as an early adopter. All this will be provided free of charge for the use cases for a limited time (up to a reasonable amount of disk space and computing resources).
+In a nutshell, the accepted use cases will receive support from the Tryggve project that can include, for example, access to secure data processing environments; technical support from Tryggve; support in legal and ethical questions to make their case happen; and an opportunity to influence future developments as an early adopter. The work support according to jointly prepared implementation plan will be provided free of charge for the use cases. The Tryggve project strives to provide also access to secure data and computing services for free, for a limited time (up to a reasonable amount of disk space and computing resources), although this needs to be confirmed case by case with the project management.
 
 #### Accessing and moving research data
 * Secure data transfer, based on secure FTP

--- a/tryggve/usecase.md
+++ b/tryggve/usecase.md
@@ -72,3 +72,5 @@ for sensitive data, for example if you are unsure whether to submit a use case o
 More on **[Tryggve](https://neic.no/tryggve/)**
 
 
+
+


### PR DESCRIPTION
Created with Joel, Radovan and Antti a Tryggve Use Case page, including same info as here (https://wiki.neic.no/wiki/Tryggve_Getting_Started) + some updates.
Also added Wolanin's email address.
Link to this page needs to be added to Tryggve landing page (https://neic.no/tryggve/).