### PR TITLE
Swap frontpage events graphic to something more sciencey.

### DIFF
--- a/_includes/index.html
+++ b/_includes/index.html
@@ -39,7 +39,7 @@
     <div class="col-md-12">
       <div class="row">
         <div class="event-wrap">
-          <div class="right-event" style="background-image: url({% include baseurl %}/assets/images/checkerboard-tile-pattern.jpg);">
+          <div class="right-event" style="background-image: url({% include baseurl %}/assets/images/waves.svg);">
           </div>
           <div class="left-event">
 

--- a/assets/css/neic-styles.css
+++ b/assets/css/neic-styles.css
@@ -237,6 +237,7 @@ section.current-events .right-event{
     height: 100%;
     display: block;
     background-repeat: repeat-y;
+    opacity: 0.6;
 }
 section.current-events .event-wrap {background-color: #00948f;}
 section.mission {

--- a/assets/css/neic-styles.css
+++ b/assets/css/neic-styles.css
@@ -232,10 +232,11 @@ section.current-events .right-event{
     bottom: 0;
     position: absolute;
     /* left: 0; */
-    width: 20%;
+    width: 21%;
     right: 0;
     height: 100%;
     display: block;
+    background-repeat: repeat-y;
 }
 section.current-events .event-wrap {background-color: #00948f;}
 section.mission {

--- a/assets/images/waves.svg
+++ b/assets/images/waves.svg
@@ -1,0 +1,2611 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   id="svg8"
+   version="1.1"
+   viewBox="0 0 59.002082 271.46252"
+   height="1026"
+   width="223"
+   inkscape:version="0.92.2 (5c3e80d, 2017-08-06)"
+   sodipodi:docname="waves.svg"
+   inkscape:export-filename="/home/joel/eraseme/yohell.neic.no/assets/images/waves.png"
+   inkscape:export-xdpi="600"
+   inkscape:export-ydpi="600">
+  <sodipodi:namedview
+     inkscape:snap-page="false"
+     inkscape:window-maximized="1"
+     inkscape:window-y="27"
+     inkscape:window-x="0"
+     inkscape:window-height="1121"
+     inkscape:window-width="1920"
+     units="px"
+     showgrid="true"
+     inkscape:current-layer="layer1"
+     inkscape:document-units="mm"
+     inkscape:cy="661.69212"
+     inkscape:cx="1.9752997"
+     inkscape:zoom="1"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0"
+     borderopacity="1.0"
+     bordercolor="#666666"
+     pagecolor="#00948f"
+     id="base"
+     inkscape:snap-grids="false"
+     inkscape:snap-others="false"
+     inkscape:snap-nodes="false"
+     inkscape:snap-global="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid5103"
+       originx="0"
+       originy="0" />
+  </sodipodi:namedview>
+  <defs
+     id="defs2" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Sine"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-25.5375)">
+    <path
+       style="fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458332;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="M 53.347775,13.04842 C 64.64452,27.159642 54.958594,41.270863 36.200018,55.382086 17.441442,69.493309 -2.4914343,83.604533 0.92625067,97.715756 4.3439367,111.82698 29.728845,125.93815 45.800949,140.04937 c 16.072104,14.11122 16.051177,28.22245 1.5e-5,42.33367 -16.051161,14.11122 -41.4196193,28.22245 -44.87471033,42.33367 -3.45508997,14.11122 16.50671233,28.22245 35.27374733,42.33367 18.767035,14.11122 28.44452,28.22245 17.147785,42.33367"
+       title="cos(x)"
+       id="path4684"
+       inkscape:connector-curvature="0" />
+    <g
+       id="g5158"
+       transform="translate(0,-89.958338)">
+      <path
+         sodipodi:nodetypes="cscssssc"
+         inkscape:connector-curvature="0"
+         id="path4684-9"
+         title="cos(x)"
+         d="M 53.347775,-8.1182543 C 64.644521,5.9929574 54.958593,20.104175 36.200019,34.215405 17.441442,48.326625 -2.4914344,62.437845 0.92625053,76.549069 4.3439366,90.660234 29.728845,104.77135 45.800949,118.88257 c 16.072104,14.11122 16.051178,28.22245 1.6e-5,42.33367 C 29.749802,175.32746 4.3813444,189.43869 0.92625353,203.54991 -2.5288364,217.66113 17.432966,231.77236 36.2,245.88358 c 18.767036,14.11121 22.123727,24.1589 21.819288,29.74203"
+         style="fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458332;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="cscssssc"
+         inkscape:connector-curvature="0"
+         id="path4684-9-4"
+         title="cos(x)"
+         d="m 58.019288,275.62561 c 0.339706,8.12912 -4.499084,15.78133 -21.480308,29.79902 -18.102644,14.9434 -39.093053,28.3878 -35.675368,42.49903 3.4176863,14.11117 28.802598,28.22228 44.874698,42.3335 16.072096,14.11122 16.051176,28.22245 2e-5,42.33367 -16.05117,14.11122 -41.4196237,28.22245 -44.874715,42.33366 -3.45509,14.11122 16.506715,28.22245 35.273745,42.33367 18.767036,14.11121 28.444516,28.22244 17.147786,42.33368"
+         style="fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458332;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+    </g>
+    <path
+       style="fill:#001122;fill-opacity:0;stroke:#00626b;stroke-width:0.24065843;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 14.43792,-104.96513 c -9.3457952,14.111674 -1.332629,28.223357 14.186335,42.335054 15.518967,14.111685 32.009431,28.223371 29.181981,42.335061 C 54.978785,-6.1833842 33.977856,7.9281976 20.681408,22.039883 7.3849598,36.151569 7.4022718,50.263265 20.681395,64.374951 33.960519,78.486637 54.947839,92.598332 57.806233,106.71002 60.664629,120.8217 44.150234,134.9334 28.624271,149.04508 13.098306,163.15676 10.321316,173.20479 10.573179,178.7881"
+       title="cos(x)"
+       id="path4684-9-40"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cscssssc" />
+    <path
+       style="fill:#001122;fill-opacity:0;stroke:#00626b;stroke-width:0.24065843;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 10.573179,178.7881 c -0.281039,8.12939 3.722091,15.78184 17.770654,29.8 14.976313,14.94389 32.341675,28.38874 29.514224,42.50043 -2.827451,14.11163 -23.828383,28.22322 -37.124828,42.3349 -13.2964414,14.11168 -13.2791343,28.22338 -1.6e-5,42.33507 13.279129,14.11169 34.266445,28.22338 37.124842,42.33505 2.858395,14.11169 -13.656002,28.22339 -29.181962,42.33507 C 13.150128,434.5403 5.1439511,448.65199 14.489734,462.7637"
+       title="cos(x)"
+       id="path4684-9-4-7"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cscssssc" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734"
+       width="2.917906"
+       height="0.80123931"
+       x="2.765029"
+       y="136.97734" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-1"
+       width="2.917906"
+       height="0.80123931"
+       x="7.0170641"
+       y="136.97734" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#e7f2f0;fill-opacity:1;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-5"
+       width="2.917906"
+       height="0.80123931"
+       x="11.241405"
+       y="136.97734" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#e7f2f0;fill-opacity:1;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-9"
+       width="2.917906"
+       height="0.80123931"
+       x="15.474547"
+       y="136.98026" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#e7f2f0;fill-opacity:1;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-91"
+       width="2.917906"
+       height="0.80123931"
+       x="23.942032"
+       y="136.98148" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-4"
+       width="2.917906"
+       height="0.80123931"
+       x="19.709806"
+       y="136.98112" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-10"
+       width="2.917906"
+       height="0.80123931"
+       x="2.765029"
+       y="141.36307" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-1-7"
+       width="2.917906"
+       height="0.80123931"
+       x="7.0170641"
+       y="141.36307" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#e7f2f0;fill-opacity:1;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-5-5"
+       width="2.917906"
+       height="0.80123931"
+       x="11.241405"
+       y="141.36307" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-9-8"
+       width="2.917906"
+       height="0.80123931"
+       x="15.474547"
+       y="141.36598" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#e7f2f0;fill-opacity:1;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-91-7"
+       width="2.917906"
+       height="0.80123931"
+       x="23.942032"
+       y="141.3672" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#e7f2f0;fill-opacity:1;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-8"
+       width="2.917906"
+       height="0.80123931"
+       x="2.765029"
+       y="139.90115" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#e7f2f0;fill-opacity:1;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-9-2"
+       width="2.917906"
+       height="0.80123931"
+       x="15.474547"
+       y="139.90407" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-4-6"
+       width="2.917906"
+       height="0.80123931"
+       x="19.709806"
+       y="139.90494" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-1-4"
+       width="2.917906"
+       height="0.80123931"
+       x="7.0170641"
+       y="138.43924" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-5-2"
+       width="2.917906"
+       height="0.80123931"
+       x="11.241405"
+       y="138.43924" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-91-0"
+       width="2.917906"
+       height="0.80123931"
+       x="23.942032"
+       y="138.44337" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-1-9"
+       width="2.917906"
+       height="0.80123931"
+       x="7.0170641"
+       y="142.82497" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-4-8"
+       width="2.917906"
+       height="0.80123931"
+       x="19.709806"
+       y="142.82875" />
+    <rect
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-40"
+       width="2.917906"
+       height="0.80123931"
+       x="-26.859938"
+       y="144.25826"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#e7f2f0;fill-opacity:1;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-5-9"
+       width="2.917906"
+       height="0.80123931"
+       x="-18.392454"
+       y="144.25703"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#e7f2f0;fill-opacity:1;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-9-6"
+       width="2.917906"
+       height="0.80123931"
+       x="-14.159311"
+       y="144.25412"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#e7f2f0;fill-opacity:1;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-91-2"
+       width="2.917906"
+       height="0.80123931"
+       x="-5.6829352"
+       y="144.25412"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-4-54"
+       width="2.917906"
+       height="0.80123931"
+       x="-9.9349699"
+       y="144.25412"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-10-4"
+       width="2.917906"
+       height="0.80123931"
+       x="-26.859938"
+       y="148.64398"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-1-7-9"
+       width="2.917906"
+       height="0.80123931"
+       x="-22.627712"
+       y="148.64363"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#e7f2f0;fill-opacity:1;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-5-5-9"
+       width="2.917906"
+       height="0.80123931"
+       x="-18.392454"
+       y="148.64276"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-9-8-3"
+       width="2.917906"
+       height="0.80123931"
+       x="-14.159311"
+       y="148.63985"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#e7f2f0;fill-opacity:1;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-8-0"
+       width="2.917906"
+       height="0.80123931"
+       x="-26.859938"
+       y="147.18207"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-5-4-5"
+       width="2.917906"
+       height="0.80123931"
+       x="-18.392454"
+       y="147.18085"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#e7f2f0;fill-opacity:1;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-9-2-0"
+       width="2.917906"
+       height="0.80123931"
+       x="-14.159311"
+       y="147.17793"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-91-9-2"
+       width="2.917906"
+       height="0.80123931"
+       x="-5.6829352"
+       y="147.17793"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-1-4-4"
+       width="2.917906"
+       height="0.80123931"
+       x="-22.627712"
+       y="145.7198"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#e7f2f0;fill-opacity:1;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-4-5-7"
+       width="2.917906"
+       height="0.80123931"
+       x="-9.9349699"
+       y="145.71602"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-1-9-4"
+       width="2.917906"
+       height="0.80123931"
+       x="-22.627712"
+       y="150.10551"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-5-0-3"
+       width="2.917906"
+       height="0.80123931"
+       x="-18.392454"
+       y="150.10464"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#e7f2f0;fill-opacity:1;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-9-28-1"
+       width="2.917906"
+       height="0.80123931"
+       x="-14.159311"
+       y="150.10173"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#e7f2f0;fill-opacity:1;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-91-3-4"
+       width="2.917906"
+       height="0.80123931"
+       x="-5.6829352"
+       y="150.10173"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-4-8-6"
+       width="2.917906"
+       height="0.80123931"
+       x="-9.9349699"
+       y="150.10173"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-7"
+       width="2.917906"
+       height="0.80123931"
+       x="2.765029"
+       y="154.88284" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-1-0"
+       width="2.917906"
+       height="0.80123931"
+       x="7.0170641"
+       y="154.88284" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#e7f2f0;fill-opacity:1;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-5-8"
+       width="2.917906"
+       height="0.80123931"
+       x="11.241405"
+       y="154.88284" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#e7f2f0;fill-opacity:1;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-9-62"
+       width="2.917906"
+       height="0.80123931"
+       x="15.474547"
+       y="154.88576" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#e7f2f0;fill-opacity:1;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-91-4"
+       width="2.917906"
+       height="0.80123931"
+       x="23.942032"
+       y="154.88698" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-4-7"
+       width="2.917906"
+       height="0.80123931"
+       x="19.709806"
+       y="154.88663" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-10-9"
+       width="2.917906"
+       height="0.80123931"
+       x="2.765029"
+       y="159.26857" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-1-7-3"
+       width="2.917906"
+       height="0.80123931"
+       x="7.0170641"
+       y="159.26857" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#e7f2f0;fill-opacity:1;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-5-5-92"
+       width="2.917906"
+       height="0.80123931"
+       x="11.241405"
+       y="159.26857" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#e7f2f0;fill-opacity:1;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-91-7-3"
+       width="2.917906"
+       height="0.80123931"
+       x="23.942032"
+       y="159.27271" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#e7f2f0;fill-opacity:1;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-8-01"
+       width="2.917906"
+       height="0.80123931"
+       x="2.765029"
+       y="157.80666" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#e7f2f0;fill-opacity:1;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-9-2-8"
+       width="2.917906"
+       height="0.80123931"
+       x="15.474547"
+       y="157.80957" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-91-9-9"
+       width="2.917906"
+       height="0.80123931"
+       x="23.942032"
+       y="157.81079" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-4-6-1"
+       width="2.917906"
+       height="0.80123931"
+       x="19.709806"
+       y="157.81044" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-1-4-5"
+       width="2.917906"
+       height="0.80123931"
+       x="7.0170641"
+       y="156.34474" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-5-2-4"
+       width="2.917906"
+       height="0.80123931"
+       x="11.241405"
+       y="156.34474" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-9-22-9"
+       width="2.917906"
+       height="0.80123931"
+       x="15.474547"
+       y="156.34766" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-1-9-7"
+       width="2.917906"
+       height="0.80123931"
+       x="7.0170641"
+       y="160.73047" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#e7f2f0;fill-opacity:1;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-9-28-9"
+       width="2.917906"
+       height="0.80123931"
+       x="15.474547"
+       y="160.73338" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-4-8-4"
+       width="2.917906"
+       height="0.80123931"
+       x="19.709806"
+       y="160.73425" />
+    <rect
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-1-91-3"
+       width="2.917906"
+       height="0.80123931"
+       x="-22.627712"
+       y="162.16341"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#e7f2f0;fill-opacity:1;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-9-6-7"
+       width="2.917906"
+       height="0.80123931"
+       x="-14.159311"
+       y="162.15962"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#e7f2f0;fill-opacity:1;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-91-2-0"
+       width="2.917906"
+       height="0.80123931"
+       x="-5.6829352"
+       y="162.15962"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-1-7-9-9"
+       width="2.917906"
+       height="0.80123931"
+       x="-22.627712"
+       y="166.54912"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#e7f2f0;fill-opacity:1;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-5-5-9-9"
+       width="2.917906"
+       height="0.80123931"
+       x="-18.392454"
+       y="166.54825"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-9-8-3-7"
+       width="2.917906"
+       height="0.80123931"
+       x="-14.159311"
+       y="166.54533"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#e7f2f0;fill-opacity:1;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-8-0-8"
+       width="2.917906"
+       height="0.80123931"
+       x="-26.859938"
+       y="165.08755"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-5-4-5-2"
+       width="2.917906"
+       height="0.80123931"
+       x="-18.392454"
+       y="165.08633"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#e7f2f0;fill-opacity:1;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-9-2-0-5"
+       width="2.917906"
+       height="0.80123931"
+       x="-14.159311"
+       y="165.08342"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-91-9-2-3"
+       width="2.917906"
+       height="0.80123931"
+       x="-5.6829352"
+       y="165.08342"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-1-4-4-9"
+       width="2.917906"
+       height="0.80123931"
+       x="-22.627712"
+       y="163.62531"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-5-0-3-6"
+       width="2.917906"
+       height="0.80123931"
+       x="-18.392454"
+       y="168.01015"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#e7f2f0;fill-opacity:1;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-91-3-4-1"
+       width="2.917906"
+       height="0.80123931"
+       x="-5.6829352"
+       y="168.00723"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-4-8-6-2"
+       width="2.917906"
+       height="0.80123931"
+       x="-9.9349699"
+       y="168.00723"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-73"
+       width="2.917906"
+       height="0.80123931"
+       x="30.820652"
+       y="136.98112" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-10-7"
+       width="2.917906"
+       height="0.80123931"
+       x="30.820652"
+       y="141.36685" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-1-7-4"
+       width="2.917906"
+       height="0.80123931"
+       x="35.054466"
+       y="141.33826" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#e7f2f0;fill-opacity:1;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-8-7"
+       width="2.917906"
+       height="0.80123931"
+       x="30.820652"
+       y="139.90494" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-5-4-4"
+       width="2.917906"
+       height="0.80123931"
+       x="39.288433"
+       y="139.87338" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-5-0-2"
+       width="2.917906"
+       height="0.80123931"
+       x="39.288433"
+       y="142.7972" />
+    <rect
+       style="display:inline;fill:#e7f2f0;fill-opacity:1;stroke:#e7f2f0;stroke-width:0.26458332;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-5-9-0"
+       width="2.917906"
+       height="0.80123931"
+       x="-46.443073"
+       y="144.23448"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#e7f2f0;fill-opacity:1;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-91-2-3"
+       width="2.917906"
+       height="0.80123931"
+       x="-33.738556"
+       y="144.2579"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-4-54-7"
+       width="2.917906"
+       height="0.80123931"
+       x="-37.972374"
+       y="144.22931"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-9-8-3-4"
+       width="2.917906"
+       height="0.80123931"
+       x="-42.206341"
+       y="148.61208"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458332;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-5-4-5-20"
+       width="2.917906"
+       height="0.80123931"
+       x="-46.443073"
+       y="147.15829"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-91-9-2-9"
+       width="2.917906"
+       height="0.80123931"
+       x="-33.738556"
+       y="147.18172"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-4-6-9-0"
+       width="2.917906"
+       height="0.80123931"
+       x="-37.972374"
+       y="147.15312"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-91-0-1-1"
+       width="2.917906"
+       height="0.80123931"
+       x="-33.738556"
+       y="145.7198"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#e7f2f0;fill-opacity:1;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-91-3-4-8"
+       width="2.917906"
+       height="0.80123931"
+       x="-33.738556"
+       y="150.10551"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-4-8-6-6"
+       width="2.917906"
+       height="0.80123931"
+       x="-37.972374"
+       y="150.07692"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-6"
+       width="2.917906"
+       height="0.80123931"
+       x="30.820652"
+       y="154.32536" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#e7f2f0;fill-opacity:1;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-5-09"
+       width="2.917906"
+       height="0.80123931"
+       x="39.288433"
+       y="154.29381" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#e7f2f0;fill-opacity:1;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-8-9"
+       width="2.917906"
+       height="0.80123931"
+       x="30.820652"
+       y="157.24918" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-1-4-1"
+       width="2.917906"
+       height="0.80123931"
+       x="35.054466"
+       y="155.75867" />
+    <rect
+       style="display:inline;fill:#e7f2f0;fill-opacity:1;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-91-2-9"
+       width="2.917906"
+       height="0.80123931"
+       x="-33.738556"
+       y="161.60213"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#e7f2f0;fill-opacity:1;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-91-2-4"
+       width="2.917906"
+       height="0.80123931"
+       x="-5.6829352"
+       y="109.10993"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-91-9-2-38"
+       width="2.917906"
+       height="0.80123931"
+       x="-5.6829352"
+       y="112.03374"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-4-6-9-52"
+       width="2.917906"
+       height="0.80123931"
+       x="-9.9349699"
+       y="112.03374"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-91-0-1-03"
+       width="2.917906"
+       height="0.80123931"
+       x="-5.6829352"
+       y="110.57187"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#e7f2f0;fill-opacity:1;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-91-3-4-3"
+       width="2.917906"
+       height="0.80123931"
+       x="-5.6829352"
+       y="114.95757"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-4-8-6-3"
+       width="2.917906"
+       height="0.80123931"
+       x="-9.9349699"
+       y="114.95757"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-7-4"
+       width="2.917906"
+       height="0.80123931"
+       x="2.765029"
+       y="119.73867" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-1-0-4"
+       width="2.917906"
+       height="0.80123931"
+       x="7.0170641"
+       y="119.73867" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-10-9-5"
+       width="2.917906"
+       height="0.80123931"
+       x="2.765029"
+       y="124.12439" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#e7f2f0;fill-opacity:1;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-5-5-92-9"
+       width="2.917906"
+       height="0.80123931"
+       x="11.241405"
+       y="124.12439" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-9-8-8-0"
+       width="2.917906"
+       height="0.80123931"
+       x="15.474547"
+       y="124.12731" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#e7f2f0;fill-opacity:1;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-8-01-4"
+       width="2.917906"
+       height="0.80123931"
+       x="2.765029"
+       y="122.66249" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-5-4-7-7"
+       width="2.917906"
+       height="0.80123931"
+       x="11.241405"
+       y="122.66249" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-1-4-5-1"
+       width="2.917906"
+       height="0.80123931"
+       x="7.0170641"
+       y="121.20057" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-9-22-9-3"
+       width="2.917906"
+       height="0.80123931"
+       x="15.474547"
+       y="121.20349" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-1-9-7-5"
+       width="2.917906"
+       height="0.80123931"
+       x="7.0170641"
+       y="125.58631" />
+    <rect
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-1-91-3-3"
+       width="2.917906"
+       height="0.80123931"
+       x="-22.627712"
+       y="127.01923"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#e7f2f0;fill-opacity:1;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-5-9-5-5"
+       width="2.917906"
+       height="0.80123931"
+       x="-18.392454"
+       y="127.01838"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#e7f2f0;fill-opacity:1;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-9-6-7-0"
+       width="2.917906"
+       height="0.80123931"
+       x="-14.159311"
+       y="127.01546"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#e7f2f0;fill-opacity:1;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-91-2-0-8"
+       width="2.917906"
+       height="0.80123931"
+       x="-5.6829352"
+       y="127.01546"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-10-4-1-4"
+       width="2.917906"
+       height="0.80123931"
+       x="-26.859938"
+       y="131.40527"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-1-7-9-9-1"
+       width="2.917906"
+       height="0.80123931"
+       x="-22.627712"
+       y="131.40492"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-9-8-3-7-3"
+       width="2.917906"
+       height="0.80123931"
+       x="-14.159311"
+       y="131.40114"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#e7f2f0;fill-opacity:1;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-8-0-8-5"
+       width="2.917906"
+       height="0.80123931"
+       x="-26.859938"
+       y="129.94336"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-5-4-5-2-9"
+       width="2.917906"
+       height="0.80123931"
+       x="-18.392454"
+       y="129.94214"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#e7f2f0;fill-opacity:1;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-9-2-0-5-3"
+       width="2.917906"
+       height="0.80123931"
+       x="-14.159311"
+       y="129.93922"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-91-9-2-3-4"
+       width="2.917906"
+       height="0.80123931"
+       x="-5.6829352"
+       y="129.93922"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-4-6-9-4-1"
+       width="2.917906"
+       height="0.80123931"
+       x="-9.9349699"
+       y="129.93922"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-91-0-1-0-3"
+       width="2.917906"
+       height="0.80123931"
+       x="-5.6829352"
+       y="128.47733"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#e7f2f0;fill-opacity:1;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-4-5-7-1-5"
+       width="2.917906"
+       height="0.80123931"
+       x="-9.9349699"
+       y="128.47733"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-1-9-4-9-6"
+       width="2.917906"
+       height="0.80123931"
+       x="-22.627712"
+       y="132.86684"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-5-0-3-6-5"
+       width="2.917906"
+       height="0.80123931"
+       x="-18.392454"
+       y="132.86597"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#e7f2f0;fill-opacity:1;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-9-28-1-2-9"
+       width="2.917906"
+       height="0.80123931"
+       x="-14.159311"
+       y="132.86305"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#e7f2f0;fill-opacity:1;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-91-3-4-1-9"
+       width="2.917906"
+       height="0.80123931"
+       x="-5.6829352"
+       y="132.86305"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-4-8-6-2-0"
+       width="2.917906"
+       height="0.80123931"
+       x="-9.9349699"
+       y="132.86305"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-96"
+       width="2.9105828"
+       height="0.79391605"
+       x="2.7686906"
+       y="1.716935" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-1-06"
+       width="2.9105828"
+       height="0.79391605"
+       x="7.0207257"
+       y="1.7210691" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#e7f2f0;fill-opacity:1;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-5-49"
+       width="2.9105828"
+       height="0.79391605"
+       x="11.245067"
+       y="1.716935" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#e7f2f0;fill-opacity:1;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-91-8"
+       width="2.9105828"
+       height="0.79391605"
+       x="23.945694"
+       y="1.7210692" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-4-93"
+       width="2.9105828"
+       height="0.79391605"
+       x="19.713469"
+       y="1.7207144" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-10-1"
+       width="2.917906"
+       height="0.80123931"
+       x="2.765029"
+       y="6.1172171" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-1-7-48"
+       width="2.917906"
+       height="0.80123931"
+       x="7.0170641"
+       y="6.1172171" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#e7f2f0;fill-opacity:1;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-5-5-96"
+       width="2.917906"
+       height="0.80123931"
+       x="11.241405"
+       y="6.1172171" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-9-8-7"
+       width="2.917906"
+       height="0.80123931"
+       x="15.474547"
+       y="6.1201401" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#e7f2f0;fill-opacity:1;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-8-3"
+       width="2.917906"
+       height="0.80123931"
+       x="2.765029"
+       y="4.6553087" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-5-4-71"
+       width="2.917906"
+       height="0.80123931"
+       x="11.241405"
+       y="4.6553087" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-91-9-21"
+       width="2.917906"
+       height="0.80123931"
+       x="23.942032"
+       y="4.6594429" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-4-6-50"
+       width="2.917906"
+       height="0.80123931"
+       x="19.709806"
+       y="4.6590881" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458332;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-1-4-9"
+       width="2.917906"
+       height="0.80123931"
+       x="7.0156026"
+       y="3.2826033" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458332;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-5-2-04"
+       width="2.917906"
+       height="0.80123931"
+       x="11.239943"
+       y="3.2826033" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458332;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-9-22-01"
+       width="2.917906"
+       height="0.80123931"
+       x="15.473085"
+       y="3.2826033" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#e7f2f0;fill-opacity:1;stroke:#e7f2f0;stroke-width:0.26458332;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-4-5-74"
+       width="2.917906"
+       height="0.80123931"
+       x="19.708345"
+       y="3.2826033" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-1-9-1"
+       width="2.917906"
+       height="0.80123931"
+       x="7.0170641"
+       y="7.5791216" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#e7f2f0;fill-opacity:1;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-91-3-03"
+       width="2.917906"
+       height="0.80123931"
+       x="23.942032"
+       y="7.5832558" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-4-8-2"
+       width="2.917906"
+       height="0.80123931"
+       x="19.709806"
+       y="7.582901" />
+    <rect
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-1-91-7"
+       width="2.917906"
+       height="0.80123931"
+       x="-22.627712"
+       y="9.0120468"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#e7f2f0;fill-opacity:1;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-5-9-56"
+       width="2.917906"
+       height="0.80123931"
+       x="-18.392454"
+       y="9.0111904"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#e7f2f0;fill-opacity:1;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-9-6-5"
+       width="2.917906"
+       height="0.80123931"
+       x="-14.159311"
+       y="9.0082664"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#e7f2f0;fill-opacity:1;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-91-2-42"
+       width="2.917906"
+       height="0.80123931"
+       x="-5.6829352"
+       y="9.0082664"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-10-4-17"
+       width="2.917906"
+       height="0.80123931"
+       x="-26.859938"
+       y="13.398123"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-1-7-9-24"
+       width="2.917906"
+       height="0.80123931"
+       x="-22.627712"
+       y="13.397769"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#e7f2f0;fill-opacity:1;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-5-5-9-16"
+       width="2.917906"
+       height="0.80123931"
+       x="-18.392454"
+       y="13.396913"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-9-8-3-57"
+       width="2.917906"
+       height="0.80123931"
+       x="-14.159311"
+       y="13.393989"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#e7f2f0;fill-opacity:1;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-8-0-85"
+       width="2.917906"
+       height="0.80123931"
+       x="-26.859938"
+       y="11.936213"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-5-4-5-92"
+       width="2.917906"
+       height="0.80123931"
+       x="-18.392454"
+       y="11.935002"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-4-6-9-47"
+       width="2.917906"
+       height="0.80123931"
+       x="-9.9349699"
+       y="11.932078"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-9-22-5-1"
+       width="2.917906"
+       height="0.80123931"
+       x="-14.159311"
+       y="10.47017"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#e7f2f0;fill-opacity:1;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-4-5-7-3"
+       width="2.917906"
+       height="0.80123931"
+       x="-9.9349699"
+       y="10.47017"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-1-9-4-0"
+       width="2.917906"
+       height="0.80123931"
+       x="-22.627712"
+       y="14.859676"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-5-0-3-2"
+       width="2.917906"
+       height="0.80123931"
+       x="-18.392454"
+       y="14.85882"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#e7f2f0;fill-opacity:1;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-9-28-1-1"
+       width="2.917906"
+       height="0.80123931"
+       x="-14.159311"
+       y="14.855896"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#e7f2f0;fill-opacity:1;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-91-3-4-5"
+       width="2.917906"
+       height="0.80123931"
+       x="-5.6829352"
+       y="14.855896"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-4-8-6-65"
+       width="2.917906"
+       height="0.80123931"
+       x="-9.9349699"
+       y="14.855896"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-7-0"
+       width="2.917906"
+       height="0.80123931"
+       x="2.765029"
+       y="19.698273" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-1-0-0"
+       width="2.917906"
+       height="0.80123931"
+       x="7.0170641"
+       y="19.698273" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#e7f2f0;fill-opacity:1;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-5-8-34"
+       width="2.917906"
+       height="0.80123931"
+       x="11.241405"
+       y="19.698273" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#e7f2f0;fill-opacity:1;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-9-62-6"
+       width="2.917906"
+       height="0.80123931"
+       x="15.474547"
+       y="19.701195" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#e7f2f0;fill-opacity:1;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-91-4-6"
+       width="2.917906"
+       height="0.80123931"
+       x="23.942032"
+       y="19.702408" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-4-7-0"
+       width="2.917906"
+       height="0.80123931"
+       x="19.709806"
+       y="19.702051" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-10-9-2"
+       width="2.917906"
+       height="0.80123931"
+       x="2.765029"
+       y="24.083998" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-1-7-3-5"
+       width="2.917906"
+       height="0.80123931"
+       x="7.0170641"
+       y="24.083998" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#e7f2f0;fill-opacity:1;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-5-5-92-8"
+       width="2.917906"
+       height="0.80123931"
+       x="11.241405"
+       y="24.083998" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-9-8-8-9"
+       width="2.917906"
+       height="0.80123931"
+       x="15.474547"
+       y="24.08692" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#e7f2f0;fill-opacity:1;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-91-7-3-5"
+       width="2.917906"
+       height="0.80123931"
+       x="23.942032"
+       y="24.088133" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#e7f2f0;fill-opacity:1;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-8-01-0"
+       width="2.917906"
+       height="0.80123931"
+       x="2.765029"
+       y="22.622089" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#e7f2f0;fill-opacity:1;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-9-2-8-0"
+       width="2.917906"
+       height="0.80123931"
+       x="15.474547"
+       y="22.625011" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-91-9-9-8"
+       width="2.917906"
+       height="0.80123931"
+       x="23.942032"
+       y="22.626225" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-1-4-5-7"
+       width="2.917906"
+       height="0.80123931"
+       x="7.0170641"
+       y="21.160181" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-5-2-4-8"
+       width="2.917906"
+       height="0.80123931"
+       x="11.241405"
+       y="21.160181" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#e7f2f0;fill-opacity:1;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-4-5-5-0"
+       width="2.917906"
+       height="0.80123931"
+       x="19.709806"
+       y="21.16396" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-1-9-7-58"
+       width="2.917906"
+       height="0.80123931"
+       x="7.0170641"
+       y="25.545902" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-4-8-4-73"
+       width="2.917906"
+       height="0.80123931"
+       x="19.709806"
+       y="25.549681" />
+    <rect
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-40-9-8"
+       width="2.917906"
+       height="0.80123931"
+       x="-26.859938"
+       y="26.979181"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-1-91-3-2"
+       width="2.917906"
+       height="0.80123931"
+       x="-22.627712"
+       y="26.978825"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#e7f2f0;fill-opacity:1;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-5-9-5-3"
+       width="2.917906"
+       height="0.80123931"
+       x="-18.392454"
+       y="26.977968"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#e7f2f0;fill-opacity:1;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-9-6-7-07"
+       width="2.917906"
+       height="0.80123931"
+       x="-14.159311"
+       y="26.975046"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#e7f2f0;fill-opacity:1;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-91-2-0-7"
+       width="2.917906"
+       height="0.80123931"
+       x="-5.6829352"
+       y="26.975046"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-4-54-8-7"
+       width="2.917906"
+       height="0.80123931"
+       x="-9.9349699"
+       y="26.975046"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-10-4-1-6"
+       width="2.917906"
+       height="0.80123931"
+       x="-26.859938"
+       y="31.364902"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-1-7-9-9-9"
+       width="2.917906"
+       height="0.80123931"
+       x="-22.627712"
+       y="31.364546"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#e7f2f0;fill-opacity:1;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-5-5-9-9-11"
+       width="2.917906"
+       height="0.80123931"
+       x="-18.392454"
+       y="31.363689"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-9-8-3-7-9"
+       width="2.917906"
+       height="0.80123931"
+       x="-14.159311"
+       y="31.360767"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#e7f2f0;fill-opacity:1;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-8-0-8-0"
+       width="2.917906"
+       height="0.80123931"
+       x="-26.859938"
+       y="29.90299"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-5-4-5-2-8"
+       width="2.917906"
+       height="0.80123931"
+       x="-18.392454"
+       y="29.901777"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-91-9-2-3-8"
+       width="2.917906"
+       height="0.80123931"
+       x="-5.6829352"
+       y="29.898855"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-4-6-9-4-8"
+       width="2.917906"
+       height="0.80123931"
+       x="-9.9349699"
+       y="29.898855"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-1-4-4-9-0"
+       width="2.917906"
+       height="0.80123931"
+       x="-22.627712"
+       y="28.440729"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-9-22-5-2-7"
+       width="2.917906"
+       height="0.80123931"
+       x="-14.159311"
+       y="28.436951"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-1-9-4-9-9"
+       width="2.917906"
+       height="0.80123931"
+       x="-22.627712"
+       y="32.826458"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#e7f2f0;fill-opacity:1;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-9-28-1-2-1"
+       width="2.917906"
+       height="0.80123931"
+       x="-14.159311"
+       y="32.822678"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#e7f2f0;fill-opacity:1;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-91-3-4-1-7"
+       width="2.917906"
+       height="0.80123931"
+       x="-5.6829352"
+       y="32.822678"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-4-8-6-2-7"
+       width="2.917906"
+       height="0.80123931"
+       x="-9.9349699"
+       y="32.822678"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-73-9"
+       width="2.9105828"
+       height="0.79391605"
+       x="30.824314"
+       y="1.7207144" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-10-7-6"
+       width="2.917906"
+       height="0.80123931"
+       x="30.820652"
+       y="6.1209965" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-1-7-4-2"
+       width="2.917906"
+       height="0.80123931"
+       x="35.054466"
+       y="6.0924125" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#e7f2f0;fill-opacity:1;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-5-5-0-7"
+       width="2.917906"
+       height="0.80123931"
+       x="39.288433"
+       y="6.0894461" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#e7f2f0;fill-opacity:1;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-8-7-8"
+       width="2.917906"
+       height="0.80123931"
+       x="30.820652"
+       y="4.6590881" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-5-4-4-4"
+       width="2.917906"
+       height="0.80123931"
+       x="39.288433"
+       y="4.6275377" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458332;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-1-4-6-6"
+       width="2.917906"
+       height="0.80123931"
+       x="35.053005"
+       y="3.2826033" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-1-9-6-8"
+       width="2.917906"
+       height="0.80123931"
+       x="35.054466"
+       y="7.554317" />
+    <rect
+       style="display:inline;fill:#e7f2f0;fill-opacity:1;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-9-6-1-5"
+       width="2.917906"
+       height="0.80123931"
+       x="-42.206341"
+       y="8.9804955"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#e7f2f0;fill-opacity:1;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-91-2-3-0"
+       width="2.917906"
+       height="0.80123931"
+       x="-33.738556"
+       y="9.0120468"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#e7f2f0;fill-opacity:1;stroke:#e7f2f0;stroke-width:0.26458332;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-5-5-9-6-2"
+       width="2.917906"
+       height="0.80123931"
+       x="-46.443073"
+       y="13.374352"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-9-8-3-4-7"
+       width="2.917906"
+       height="0.80123931"
+       x="-42.206341"
+       y="13.366218"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458332;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-5-4-5-20-1"
+       width="2.917906"
+       height="0.80123931"
+       x="-46.443073"
+       y="11.912441"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#e7f2f0;fill-opacity:1;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-9-2-0-2-3"
+       width="2.917906"
+       height="0.80123931"
+       x="-42.206341"
+       y="11.904307"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-91-9-2-9-4"
+       width="2.917906"
+       height="0.80123931"
+       x="-33.738556"
+       y="11.935859"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-4-6-9-0-9"
+       width="2.917906"
+       height="0.80123931"
+       x="-37.972374"
+       y="11.907273"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458332;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-5-2-3-4-95"
+       width="2.917906"
+       height="0.80123931"
+       x="-46.443073"
+       y="10.450533"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-91-0-1-1-4"
+       width="2.917906"
+       height="0.80123931"
+       x="-33.738556"
+       y="10.47395"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#e7f2f0;fill-opacity:1;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-4-5-7-0-1"
+       width="2.917906"
+       height="0.80123931"
+       x="-37.972374"
+       y="10.445365"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#e7f2f0;fill-opacity:1;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-91-3-4-8-2"
+       width="2.917906"
+       height="0.80123931"
+       x="-33.738556"
+       y="14.859676"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-4-8-6-6-0"
+       width="2.917906"
+       height="0.80123931"
+       x="-37.972374"
+       y="14.831091"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-6-2"
+       width="2.917906"
+       height="0.80123931"
+       x="30.820652"
+       y="19.140781" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-1-76-2"
+       width="2.917906"
+       height="0.80123931"
+       x="35.054466"
+       y="19.112198" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#e7f2f0;fill-opacity:1;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-5-09-9"
+       width="2.917906"
+       height="0.80123931"
+       x="39.288433"
+       y="19.109232" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-10-78-5"
+       width="2.917906"
+       height="0.80123931"
+       x="30.820652"
+       y="23.526503" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#e7f2f0;fill-opacity:1;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-8-9-31"
+       width="2.917906"
+       height="0.80123931"
+       x="30.820652"
+       y="22.064594" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-1-4-1-8"
+       width="2.917906"
+       height="0.80123931"
+       x="35.054466"
+       y="20.574106" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-1-9-8-0"
+       width="2.917906"
+       height="0.80123931"
+       x="35.054466"
+       y="24.959827" />
+    <rect
+       style="display:inline;fill:#e7f2f0;fill-opacity:1;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-91-2-9-2"
+       width="2.917906"
+       height="0.80123931"
+       x="-33.738556"
+       y="26.417555"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#e7f2f0;fill-opacity:1;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-91-2-4-3-4"
+       width="2.917906"
+       height="0.80123931"
+       x="-5.6829352"
+       y="245.70032"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-91-9-2-38-7-5"
+       width="2.917906"
+       height="0.80123931"
+       x="-5.6829352"
+       y="248.62415"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-91-0-1-03-0-6"
+       width="2.917906"
+       height="0.80123931"
+       x="-5.6829352"
+       y="247.16223"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#e7f2f0;fill-opacity:1;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-91-3-4-3-5-3"
+       width="2.917906"
+       height="0.80123931"
+       x="-5.6829352"
+       y="251.54794"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-4-8-6-3-4-6"
+       width="2.917906"
+       height="0.80123931"
+       x="-9.9349699"
+       y="251.54794"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-7-4-2-7"
+       width="2.917906"
+       height="0.80123931"
+       x="2.765029"
+       y="256.32904" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-1-0-4-4-8"
+       width="2.917906"
+       height="0.80123931"
+       x="7.0170641"
+       y="256.32904" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#e7f2f0;fill-opacity:1;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-5-8-3-9-7"
+       width="2.917906"
+       height="0.80123931"
+       x="11.241405"
+       y="256.32904" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-10-9-5-9-2"
+       width="2.917906"
+       height="0.80123931"
+       x="2.765029"
+       y="260.71475" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-1-7-3-8-8-9"
+       width="2.917906"
+       height="0.80123931"
+       x="7.0170641"
+       y="260.71475" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#e7f2f0;fill-opacity:1;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-5-5-92-9-1-7"
+       width="2.917906"
+       height="0.80123931"
+       x="11.241405"
+       y="260.71475" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-9-8-8-0-6-0"
+       width="2.917906"
+       height="0.80123931"
+       x="15.474547"
+       y="260.71768" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#e7f2f0;fill-opacity:1;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-8-01-4-9-7"
+       width="2.917906"
+       height="0.80123931"
+       x="2.765029"
+       y="259.25287" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-5-4-7-7-3-2"
+       width="2.917906"
+       height="0.80123931"
+       x="11.241405"
+       y="259.25287" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#e7f2f0;fill-opacity:1;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-9-2-8-6-3-3"
+       width="2.917906"
+       height="0.80123931"
+       x="15.474547"
+       y="259.2558" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-1-4-5-1-1-7"
+       width="2.917906"
+       height="0.80123931"
+       x="7.0170641"
+       y="257.79099" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-5-2-4-3-5-8"
+       width="2.917906"
+       height="0.80123931"
+       x="11.241405"
+       y="257.79099" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-9-22-9-3-6-9"
+       width="2.917906"
+       height="0.80123931"
+       x="15.474547"
+       y="257.79391" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-1-9-7-5-2-6"
+       width="2.917906"
+       height="0.80123931"
+       x="7.0170641"
+       y="262.1767" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-5-0-4-1-2-4"
+       width="2.917906"
+       height="0.80123931"
+       x="11.241405"
+       y="262.1767" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#e7f2f0;fill-opacity:1;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-9-28-9-0-9-3"
+       width="2.917906"
+       height="0.80123931"
+       x="15.474547"
+       y="262.17963" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-4-8-4-7-8-4"
+       width="2.917906"
+       height="0.80123931"
+       x="19.709806"
+       y="262.18048" />
+    <rect
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-40-9-6-1-8"
+       width="2.917906"
+       height="0.80123931"
+       x="-26.859938"
+       y="263.60995"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-1-91-3-3-2-7"
+       width="2.917906"
+       height="0.80123931"
+       x="-22.627712"
+       y="263.60959"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#e7f2f0;fill-opacity:1;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-5-9-5-5-4-3"
+       width="2.917906"
+       height="0.80123931"
+       x="-18.392454"
+       y="263.60873"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#e7f2f0;fill-opacity:1;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-9-6-7-0-7-3"
+       width="2.917906"
+       height="0.80123931"
+       x="-14.159311"
+       y="263.6058"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#e7f2f0;fill-opacity:1;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-91-2-0-8-8-5"
+       width="2.917906"
+       height="0.80123931"
+       x="-5.6829352"
+       y="263.6058"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-4-54-8-0-6-0"
+       width="2.917906"
+       height="0.80123931"
+       x="-9.9349699"
+       y="263.6058"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-10-4-1-4-3-1"
+       width="2.917906"
+       height="0.80123931"
+       x="-26.859938"
+       y="267.9957"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-1-7-9-9-1-7-4"
+       width="2.917906"
+       height="0.80123931"
+       x="-22.627712"
+       y="267.99533"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#e7f2f0;fill-opacity:1;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-5-5-9-9-1-7-5"
+       width="2.917906"
+       height="0.80123931"
+       x="-18.392454"
+       y="267.99448"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-9-8-3-7-3-2-7"
+       width="2.917906"
+       height="0.80123931"
+       x="-14.159311"
+       y="267.99155"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#e7f2f0;fill-opacity:1;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-8-0-8-5-3-0"
+       width="2.917906"
+       height="0.80123931"
+       x="-26.859938"
+       y="266.53378"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-5-4-5-2-9-7-7"
+       width="2.917906"
+       height="0.80123931"
+       x="-18.392454"
+       y="266.53256"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#e7f2f0;fill-opacity:1;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-9-2-0-5-3-2-8"
+       width="2.917906"
+       height="0.80123931"
+       x="-14.159311"
+       y="266.52963"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-91-9-2-3-4-5-9"
+       width="2.917906"
+       height="0.80123931"
+       x="-5.6829352"
+       y="266.52963"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-4-6-9-4-1-3-9"
+       width="2.917906"
+       height="0.80123931"
+       x="-9.9349699"
+       y="266.52963"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-1-4-4-9-5-7-3"
+       width="2.917906"
+       height="0.80123931"
+       x="-22.627712"
+       y="265.07153"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-5-2-3-0-0-6-9"
+       width="2.917906"
+       height="0.80123931"
+       x="-18.392454"
+       y="265.07068"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-9-22-5-2-8-8-4"
+       width="2.917906"
+       height="0.80123931"
+       x="-14.159311"
+       y="265.06775"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-91-0-1-0-3-1-6"
+       width="2.917906"
+       height="0.80123931"
+       x="-5.6829352"
+       y="265.06775"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#e7f2f0;fill-opacity:1;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-4-5-7-1-5-3-4"
+       width="2.917906"
+       height="0.80123931"
+       x="-9.9349699"
+       y="265.06775"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-1-9-4-9-6-6-5"
+       width="2.917906"
+       height="0.80123931"
+       x="-22.627712"
+       y="269.45724"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-5-0-3-6-5-4-5"
+       width="2.917906"
+       height="0.80123931"
+       x="-18.392454"
+       y="269.45639"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#e7f2f0;fill-opacity:1;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-9-28-1-2-9-0-5"
+       width="2.917906"
+       height="0.80123931"
+       x="-14.159311"
+       y="269.45346"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#e7f2f0;fill-opacity:1;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-91-3-4-1-9-3-6"
+       width="2.917906"
+       height="0.80123931"
+       x="-5.6829352"
+       y="269.45346"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-4-8-6-2-0-5-0"
+       width="2.917906"
+       height="0.80123931"
+       x="-9.9349699"
+       y="269.45346"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#e7f2f0;fill-opacity:1;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-91-3-4-0-2-3-2"
+       width="2.917906"
+       height="0.80123931"
+       x="-33.738556"
+       y="268.89597"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-96-3"
+       width="2.917906"
+       height="0.80123931"
+       x="2.765029"
+       y="36.773884" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-1-06-3"
+       width="2.917906"
+       height="0.80123931"
+       x="7.0170641"
+       y="36.773884" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#e7f2f0;fill-opacity:1;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-5-49-9"
+       width="2.917906"
+       height="0.80123931"
+       x="11.241405"
+       y="36.773884" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-10-1-3"
+       width="2.917906"
+       height="0.80123931"
+       x="2.765029"
+       y="41.159607" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-1-7-48-4"
+       width="2.917906"
+       height="0.80123931"
+       x="7.0170641"
+       y="41.159607" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-5-4-71-8"
+       width="2.917906"
+       height="0.80123931"
+       x="11.241405"
+       y="39.697701" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-1-4-9-1"
+       width="2.917906"
+       height="0.80123931"
+       x="7.0170641"
+       y="38.23579" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-9-22-01-8"
+       width="2.917906"
+       height="0.80123931"
+       x="15.474547"
+       y="38.238716" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-1-9-1-3"
+       width="2.917906"
+       height="0.80123931"
+       x="7.0170641"
+       y="42.621513" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-5-0-1-9"
+       width="2.917906"
+       height="0.80123931"
+       x="11.241405"
+       y="42.621513" />
+    <rect
+       style="display:inline;fill:#e7f2f0;fill-opacity:1;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-91-2-42-2"
+       width="2.917906"
+       height="0.80123931"
+       x="-5.6829352"
+       y="44.050655"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-4-54-2-1"
+       width="2.917906"
+       height="0.80123931"
+       x="-9.9349699"
+       y="44.050655"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-91-9-2-36-9"
+       width="2.917906"
+       height="0.80123931"
+       x="-5.6829352"
+       y="46.974468"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-4-6-9-47-1"
+       width="2.917906"
+       height="0.80123931"
+       x="-9.9349699"
+       y="46.974468"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#e7f2f0;fill-opacity:1;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-91-3-4-5-4"
+       width="2.917906"
+       height="0.80123931"
+       x="-5.6829352"
+       y="49.898285"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-96-3-3"
+       width="2.917906"
+       height="0.80123931"
+       x="2.765029"
+       y="172.39845" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-1-06-3-8"
+       width="2.917906"
+       height="0.80123931"
+       x="7.0170641"
+       y="172.39845" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#e7f2f0;fill-opacity:1;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-5-49-9-6"
+       width="2.917906"
+       height="0.80123931"
+       x="11.241405"
+       y="172.39845" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#e7f2f0;fill-opacity:1;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-9-90-0-7"
+       width="2.917906"
+       height="0.80123931"
+       x="15.474547"
+       y="172.40137" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-10-1-3-1"
+       width="2.917906"
+       height="0.80123931"
+       x="2.765029"
+       y="176.78416" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-1-7-48-4-9"
+       width="2.917906"
+       height="0.80123931"
+       x="7.0170641"
+       y="176.78416" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#e7f2f0;fill-opacity:1;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-5-5-96-2-8"
+       width="2.917906"
+       height="0.80123931"
+       x="11.241405"
+       y="176.78416" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#e7f2f0;fill-opacity:1;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-8-3-3-4"
+       width="2.917906"
+       height="0.80123931"
+       x="2.765029"
+       y="175.32228" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-1-4-9-1-5"
+       width="2.917906"
+       height="0.80123931"
+       x="7.0170641"
+       y="173.86037" />
+    <rect
+       transform="translate(0,25.5375)"
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-1-9-1-3-2"
+       width="2.917906"
+       height="0.80123931"
+       x="7.0170641"
+       y="178.24608" />
+    <rect
+       style="display:inline;fill:#e7f2f0;fill-opacity:1;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-91-2-42-2-1"
+       width="2.917906"
+       height="0.80123931"
+       x="-5.6829352"
+       y="179.67522"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-91-9-2-36-9-8"
+       width="2.917906"
+       height="0.80123931"
+       x="-5.6829352"
+       y="182.59904"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#001122;fill-opacity:0;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-91-0-1-6-1-2"
+       width="2.917906"
+       height="0.80123931"
+       x="-5.6829352"
+       y="181.13713"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+    <rect
+       style="display:inline;fill:#e7f2f0;fill-opacity:1;stroke:#e7f2f0;stroke-width:0.26458333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4734-91-3-4-5-4-0"
+       width="2.917906"
+       height="0.80123931"
+       x="-5.6829352"
+       y="185.52286"
+       transform="matrix(-1,0,0,1,0,25.5375)" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="Boxes"
+     style="display:inline" />
+</svg>


### PR DESCRIPTION
Quieted down the sinewave and blinker lights after Caela's comments.

* Go here: https://yohell.github.io/neic.no/#events
* Megarefresh with Ctrl-Shift-R to make sure styles are reloaded.
* See that bathroom tiles are gone, science is here, which vaguely looks like server blinker lights and DNA like sine waves.