### PR TITLE
Remove description text from events on training pages.

### DIFF
--- a/_includes/training-event.html
+++ b/_includes/training-event.html
@@ -1,0 +1,6 @@
+<h4><a :href="event.url" v-text="event.title.toUpperCase()" target="_blank"></a></h4>
+
+<h6 class="date">
+<span v-html="event.dates.start + (event.dates.end ? ' &ndash; ' + event.dates.end : '')"></span>
+<a class="anchorjs-link " :href="event.calendarUrl" :aria-label="'Calendar link for: ' + event.title.toLowerCase()" data-anchorjs-icon="📅" style="font-style: normal; font-variant: normal; font-weight: normal; font-stretch: normal; font-size: 1em; line-height: 1; font-family: anchorjs-icons; padding-left: 0.375em;" target="_blank"></a>
+</h6>

--- a/_includes/training-past.html
+++ b/_includes/training-past.html
@@ -15,7 +15,7 @@
               <div v-for="event in events">
                 <div class="single-publications-list">
                   <div class="publications-details">
-                    {% include event.html %}
+                    {% include training-event.html %}
                   </div>
                 </div>
               </div>

--- a/_includes/training-upcoming.html
+++ b/_includes/training-upcoming.html
@@ -15,7 +15,7 @@
               <div v-for="event in events">
                 <div class="single-publications-list">
                   <div class="publications-details">
-                    {% include event.html %}
+                    {% include training-event.html %}
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
Examples:
* https://yohell.github.io/neic.no/training/upcoming/
* https://yohell.github.io/neic.no/training/past/

@ambach would you check that looks ok? If you think it's ok you can approve it and the changes will go live.