### PR TITLE
Add ESM training pages.

### DIFF
--- a/_activities/nicest.md
+++ b/_activities/nicest.md
@@ -7,23 +7,24 @@ leader: joel-hedlund
 phase: Execution
 start: 2017-01-01
 end: 2019-12-31
-results:
-outreach: https://wiki.neic.no/wiki/Earth_system_modeling#Outreach
+results: N/A
+outreach: N/A
+outreach-tags: nicest,outreach
 documents:
   - text: Work plan
     url: https://wiki.neic.no/wiki/File:20161125_NeIC_ESM_work_plan_approved.pdf
 links:
+  - url: /training/esm/upcoming
+    text: ESM training calendar
+    description: Upcoming training events relevant to the ESM community.
+  - url: /training/esm/past
+    text: "Past events"
   - url: https://wiki.neic.no/wiki/Earth_system_modeling
     text: External wiki
     description: External documentation, manuals and guides.
   - url: https://wiki.neic.no/int/Earth_system_modeling
     text: Internal wiki
     description: Internal working documents.
-  - url: /training/upcoming/esm
-    text: ESM training calendar
-    description: Upcoming training events relevant to the ESM community.
-  - url: /training/past/esm
-    text: Past training events
 groups:
   nicest:
     name: Team
@@ -52,7 +53,7 @@ Nordic Infrastructure Collaboration on Earth System Tools
 ### Activity B - ESM competence building
 
 * [Documentation & best practice guides](https://wiki.neic.no/wiki/ESM_activity_B_documentation)
-* [ESM training calendar](/training/upcoming/esm) (past events [here](/training/past/esm))
+* [ESM training calendar](/training/esm/upcoming) (past events [here](/training/esm/past))
 * [Information for new NorESM users](https://wiki.neic.no/wiki/ESM_activity_B_noresm_new_users_info)
 * [Competence requirements and gap analysis](https://wiki.neic.no/wiki/File:Deliverable_B.2.1_NICEST.pdf)
 
@@ -63,4 +64,6 @@ Nordic Infrastructure Collaboration on Earth System Tools
 ### Management
 
 * [NICEST Annual Report 2017](https://docs.google.com/document/d/1R3vDjVtd1nd_JlN25X_UBr46I2bZdAnK-A86Kv4TOaQ/edit)
+
+
 

--- a/_activities/nicest.md
+++ b/_activities/nicest.md
@@ -7,7 +7,7 @@ leader: joel-hedlund
 phase: Execution
 start: 2017-01-01
 end: 2019-12-31
-results: https://wiki.neic.no/wiki/Earth_system_modeling#Results
+results:
 outreach: https://wiki.neic.no/wiki/Earth_system_modeling#Outreach
 documents:
   - text: Work plan
@@ -19,6 +19,11 @@ links:
   - url: https://wiki.neic.no/int/Earth_system_modeling
     text: Internal wiki
     description: Internal working documents.
+  - url: /training/upcoming/esm
+    text: ESM training calendar
+    description: Upcoming training events relevant to the ESM community.
+  - url: /training/past/esm
+    text: Past training events
 groups:
   nicest:
     name: Team
@@ -37,3 +42,25 @@ groups:
 ---
 
 Nordic Infrastructure Collaboration on Earth System Tools
+
+## Results
+
+### Activity A - ESGF data node administration & use
+
+* [Requirements of data publication](https://wiki.neic.no/wiki/File:NICEST_D-A.2.1_report.pdf)
+
+### Activity B - ESM competence building
+
+* [Documentation & best practice guides](https://wiki.neic.no/wiki/ESM_activity_B_documentation)
+* [ESM training calendar](/training/upcoming/esm) (past events [here](/training/past/esm))
+* [Information for new NorESM users](https://wiki.neic.no/wiki/ESM_activity_B_noresm_new_users_info)
+* [Competence requirements and gap analysis](https://wiki.neic.no/wiki/File:Deliverable_B.2.1_NICEST.pdf)
+
+### Activity C - ESM data quality control
+
+* (first results due 2018h1)
+
+### Management
+
+* [NICEST Annual Report 2017](https://docs.google.com/document/d/1R3vDjVtd1nd_JlN25X_UBr46I2bZdAnK-A86Kv4TOaQ/edit)
+

--- a/_includes/training-past-esm.html
+++ b/_includes/training-past-esm.html
@@ -12,8 +12,10 @@
             This catalogue was initiated by the <a href="{% include baseurl %}/nicest/">NICEST</a> project.
           </p>
           <p>
-            You may also want to look for <a href="{% include baseurl %}/training/upcoming/esm">upcoming ESM training events</a>.
+            You may also want to look for <a href="{% include baseurl %}/training/esm/upcoming">upcoming ESM training events</a>,
+            or <a href="{% include baseurl %}/training/past">all past training events</a>.
           </p>
+
           <div class="publications-list-block">
 
             {% include noscript.html %}
@@ -41,11 +43,6 @@
         <a href="https://wiki.neic.no/wiki/Training">training calendar</a>,
         which includes both NeIC training and stakeholder training which NeIC either
         participates in or simply wants to advertize.
-
-        You may also want to look for
-        <a href="{% include baseurl %}/training/upcoming/esm/">upcoming
-        training events</a>.
-        </p>
 
         <p>
           This list is generated with JavaScript in your browser, so if you cannot see

--- a/_includes/training-past-esm.html
+++ b/_includes/training-past-esm.html
@@ -1,0 +1,65 @@
+<section class="single-pagebanner" style="background-image: url({% include baseurl %}/assets/images/upcom-banner.png);">
+</section>
+
+<section class="publications">
+  <div class="container">
+    <div class="row">
+      <div class="col-md-8">
+        <div class="content">
+          <h2>PAST ESM TRAINING EVENTS</h2>
+          <p>
+            Past training events relevant to the Earth System Modeling community.
+            This catalogue was initiated by the <a href="{% include baseurl %}/nicest/">NICEST</a> project.
+          </p>
+          <p>
+            You may also want to look for <a href="{% include baseurl %}/training/upcoming/esm">upcoming ESM training events</a>.
+          </p>
+          <div class="publications-list-block">
+
+            {% include noscript.html %}
+
+            <span id="calendar-events-list" data-calendar-name="neic-training" data-hashtags="esm" data-past="true">
+              <div v-for="event in events">
+                <div class="single-publications-list">
+                  <div class="publications-details">
+                    {% include training-event.html %}
+                  </div>
+                </div>
+              </div>
+            </span>
+
+          </div>
+        </div>
+      </div>
+
+      <div class="col-md-offset-1 col-md-3">
+
+        <p>
+        This page contains
+        past
+        events from the NeIC
+        <a href="https://wiki.neic.no/wiki/Training">training calendar</a>,
+        which includes both NeIC training and stakeholder training which NeIC either
+        participates in or simply wants to advertize.
+
+        You may also want to look for
+        <a href="{% include baseurl %}/training/upcoming/esm/">upcoming
+        training events</a>.
+        </p>
+
+        <p>
+          This list is generated with JavaScript in your browser, so if you cannot see
+          any events please check your settings.
+        </p>
+
+        <p>
+          This list will only show a limited number of past events (a few hundred).
+          To see older events than this please use another means of accessing the
+          calendar, as described on the
+          <a href="https://wiki.neic.no/wiki/Event_calendar">event calendar wiki page</a>.
+        </p>
+
+      </div>
+    </div>
+  </div>
+</section>

--- a/_includes/training-upcoming-esm.html
+++ b/_includes/training-upcoming-esm.html
@@ -1,0 +1,62 @@
+<section class="single-pagebanner" style="background-image: url({% include baseurl %}/assets/images/upcom-banner.png);">
+</section>
+
+<section class="publications">
+  <div class="container">
+    <div class="row">
+      <div class="col-md-8">
+        <div class="content">
+          <h2>UPCOMING ESM TRAINING EVENTS</h2>
+          <p>
+            Past training events relevant to the Earth System Modeling community.
+            This catalogue was initiated by the <a href="{% include baseurl %}/nicest/">NICEST</a> project.
+          </p>
+          <p>
+            You may also want to look for <a href="{% include baseurl %}/training/past/esm">past ESM training events</a>.
+          </p>
+          <div class="publications-list-block">
+
+            {% include noscript.html %}
+
+	    <span id="calendar-events-list" data-calendar-name="neic-training" data-hashtags="esm">
+              <div v-for="event in events">
+                <div class="single-publications-list">
+                  <div class="publications-details">
+                    {% include training-event.html %}
+                  </div>
+                </div>
+              </div>
+            </span>
+
+          </div>
+        </div>
+      </div>
+
+      <div class="col-md-offset-1 col-md-3">
+
+        <p>
+        This page contains
+        upcoming
+        events from the NeIC
+        <a href="https://wiki.neic.no/wiki/Training">training calendar</a>,
+        which includes both NeIC training and stakeholder training which NeIC either
+        participates in or simply wants to advertize.
+
+        Please refer to the official website for each
+        training for accurate and up-to-date information on for example admittance,
+        costs, etc.
+
+        You may also want to look for
+        <a href="{% include baseurl %}/training/past/esm">past
+        training events</a>.
+        </p>
+
+        <p>
+          This list is generated with JavaScript in your browser, so if you cannot see
+          any events please check your settings.
+        </p>
+
+      </div>
+    </div>
+  </div>
+</section>

--- a/_includes/training-upcoming-esm.html
+++ b/_includes/training-upcoming-esm.html
@@ -6,14 +6,26 @@
     <div class="row">
       <div class="col-md-8">
         <div class="content">
-          <h2>UPCOMING ESM TRAINING EVENTS</h2>
+          <h2>UPCOMING ESM TRAINING</h2>
           <p>
-            Past training events relevant to the Earth System Modeling community.
+            Upcoming training relevant to the Earth System Modeling community.
             This catalogue was initiated by the <a href="{% include baseurl %}/nicest/">NICEST</a> project.
+            If you know of a course or event suitable for publication here please
+            <a href="mailto:training@neic.no">let us know</a>!
           </p>
           <p>
-            You may also want to look for <a href="{% include baseurl %}/training/past/esm">past ESM training events</a>.
+            You may also want to look for <a href="{% include baseurl %}/training/esm/past/">past ESM training events</a>,
+            or <a href="{% include baseurl %}/training/upcoming">all upcoming training events</a>.
           </p>
+
+          <h3>Courses</h3>
+          <ul>
+            <li><a href="http://sese.nu/introduction-climate-modeling-2017/">Gunilla Svensson: Introduction to Climate Modeling</a></li>
+            <li><a href="http://www.uio.no/studier/emner/matnat/geofag/GEF4530/">Kirstin Krüger: The General Circulation of the Atmosphere</a></li>
+            <li><a href="http://www.uio.no/studier/emner/matnat/geofag/GEF4400/">Michael Schulz: The Earth System</a></li>
+          </ul>
+
+          <h3>Training Events</h3>
           <div class="publications-list-block">
 
             {% include noscript.html %}
@@ -45,11 +57,6 @@
         Please refer to the official website for each
         training for accurate and up-to-date information on for example admittance,
         costs, etc.
-
-        You may also want to look for
-        <a href="{% include baseurl %}/training/past/esm">past
-        training events</a>.
-        </p>
 
         <p>
           This list is generated with JavaScript in your browser, so if you cannot see

--- a/_includes/training-upcoming.html
+++ b/_includes/training-upcoming.html
@@ -49,6 +49,13 @@
           any events please check your settings.
         </p>
 
+        <p>
+          Topical training:
+          <ul>
+            <li><a href="../esm/upcoming/">ESM</a></li>
+          </ul>
+        </p>
+
       </div>
     </div>
   </div>

--- a/training/esm/past.md
+++ b/training/esm/past.md
@@ -1,0 +1,5 @@
+---
+layout: master
+include: training-past-esm
+permalink: /training/past/esm/
+---

--- a/training/esm/past.md
+++ b/training/esm/past.md
@@ -1,5 +1,5 @@
 ---
 layout: master
 include: training-past-esm
-permalink: /training/past/esm/
+permalink: /training/esm/past/
 ---

--- a/training/esm/upcoming.md
+++ b/training/esm/upcoming.md
@@ -1,5 +1,5 @@
 ---
 layout: master
 include: training-upcoming-esm
-permalink: /training/upcoming/esm/
+permalink: /training/esm/upcoming/
 ---

--- a/training/esm/upcoming.md
+++ b/training/esm/upcoming.md
@@ -1,0 +1,5 @@
+---
+layout: master
+include: training-upcoming-esm
+permalink: /training/upcoming/esm/
+---


### PR DESCRIPTION
Added pages to show training events relevant to the ESM community, added by NICEST.

@ambach OKed an earlier version over email, but now I've also added links from (right sidebar):
https://yohell.github.io/neic.no/training/upcoming/


Look here (also lists courses on top):
https://yohell.github.io/neic.no/training/esm/upcoming/

Past events here:
https://yohell.github.io/neic.no/training/esm/past/

Linked from here (right sidebar):
https://yohell.github.io/neic.no/training/upcoming/

Also linked from here:
https://yohell.github.io/neic.no/nicest/