### PR TITLE
Add activity.show-groups frontmatter property.

### DIFF
--- a/_activities/tryggve.md
+++ b/_activities/tryggve.md
@@ -2,7 +2,7 @@
 layout: master
 include: activity
 name: Tryggve
-type: 
+type:
 tagline: Nordic Collaboration for Sensitive Data
 leader: antti-pursula
 phase: Implementation
@@ -27,8 +27,8 @@ links:
     url: usecase
 documents:
   - text: Tryggve GDPR article (3/2018)
-    url: https://drive.google.com/open?id=11wb7dHyqRoUJSdTWztBoHEvLljG1_8H5 
-groups:
+    url: https://drive.google.com/open?id=11wb7dHyqRoUJSdTWztBoHEvLljG1_8H5
+show-groups:
   tryggve2:
     name: Team
     minutes: https://goo.gl/ngwJLK
@@ -71,5 +71,4 @@ Currently active project is [Tryggve2](https://neic.no/tryggve2/), which continu
 
 Tryggve Newsletter is sent monthly on [the Tryggve news mailing list](tryggve-news@neic.no). To subscribe or unsubscribe to the Tryggve newsletter, please go to [this page](https://neic.no/mailman/listinfo/tryggve-news).
 
-Feel free to [contact the Tryggve project](mailto:tryggve@neic.no) for more information! Follow [@NordicTryggve](https://twitter.com/nordictryggve) in Twitter for updates. 
-
+Feel free to [contact the Tryggve project](mailto:tryggve@neic.no) for more information! Follow [@NordicTryggve](https://twitter.com/nordictryggve) in Twitter for updates.

--- a/_includes/activity.html
+++ b/_includes/activity.html
@@ -151,13 +151,14 @@
         </div>
       </div>
 
-      {% if page.groups %}
+      {% assign groups = page.groups|default:page.show-groups %}
+      {% if groups %}
         <div class="col-md-offset-1 col-md-4">
           <div class="toggle-bar">
             <h2>PEOPLE</h2>
             <div class="panel-group toogle-box-small" id="sidebar-accordion" role="tablist" aria-multiselectable="true">
 
-            {% for group in page.groups %}
+            {% for group in groups %}
               {% if forloop.index == 1 %}
                 {% assign group_collapsed = '' %}
                 {% assign group_expanded = 'true' %}


### PR DESCRIPTION
@bast I added you for good taste in code complexity :)
@KineNordstokka I added you for decision making :)

I've added a new activity.show-groups frontmatter property, which makes it so that you can show groups in one activity that may really belong to another activity. 

For example, this allows neic.no/tryggve to list currently active people, which are formally active in neic.no/tryggve2, however this distinction is probably confusing/uninteresting to most people who aren't hard core bureaucrats.

The simple/stupid fix was to just copy the lists over. This made it so that people showed up as being part of two groups (eg as "reference group" in both "Tryggve" and "Tryggve2"). I've made this change so that this duplication no longer will be apparent to casuals browsing our website.

## What too look at

See people listed (old and new version):
https://neic.no/tryggve/
https://yohell.github.io/neic.no/tryggve/

See people listed twice as being part of tryggve2 groups in the old version (both as "Tryggve" and as "Tryggve2"), examples:
https://neic.no/people/bartlomiej-wilkowski/
https://neic.no/people/ulla-rudsander/
...

See people not being listed twice in the new version:
https://yohell.github.io/neic.no/people/bartlomiej-wilkowski/
https://yohell.github.io/neic.no/people/ulla-rudsander/

Question: is this any good? Is it unnecessary complexity? We will get more and more "continuations" of activities, so while this currently is only useful for Tryggve (and Glenna? And CodeRefinery?) this may get more and more useful as we go.