### PR TITLE
Revert "for CodeRefinery link to external team page"

### DIFF
--- a/_activities/coderefinery.md
+++ b/_activities/coderefinery.md
@@ -9,7 +9,6 @@ start: 2016-10-01
 end: 2021-10-31
 results: https://coderefinery.org
 outreach: https://coderefinery.org
-external_team_page: https://coderefinery.org/about/#meet-the-team
 documents:
   - text: Project directive (phase 1)
     url: https://wiki.neic.no/w/ext/img_auth.php/5/5a/Collaborative_Infrastructure_for_Scientific_Software_Project_directive.doc

--- a/_includes/activity.html
+++ b/_includes/activity.html
@@ -188,37 +188,29 @@
                     {% if group[1].minutes %}
                       <p><b>Minutes: <span class="color"><b><a href="{{ group[1].minutes }}">{{ group[1].name }} meeting minutes</a></b></span>{% if group[1].frequency %}, {{ group[1].frequency }}{% endif %}</b>.</p>
                     {% endif %}
-
-                    {% if page.external_team_page and group[1].name == 'Team' %}
-                      <p>
-                        <span class="color"><b><a href="{{ page.external_team_page }}" target="_blank">Team page</a></b></span>
-                      </p>
-                    {% else %}
-                      {% assign person_on_top = true %}
-                      {% for person in site.people %}
-                        {% for person_group in person.groups %}
-                          {% if person_group[0] == group[0] %}
-                            {% comment %}Liquid templates do not have a logic not operator {% endcomment %}
-                            {% assign display_this = true %}
-                            {% if page.finished %}
-                            {% elsif person_group[1].finished %}
-                              {% assign display_this = false %}
-                            {% endif%}
-                            {% if display_this %}
-                              {% if person_on_top %}
-                                <p class="top group-member">
-                              {% else %}
-                                <p class="group-member">
-                              {% endif %}
-                                <a href="{% include baseurl %}{{ person.url }}" class="hover-blue">{{ person.name }}</a>, {{ person.country }}{% if person_group[1].role %}, {{ person_group[1].role }}{% endif %}
-                              </p>
-                              {% assign person_on_top = false %}
+                    {% assign person_on_top = true %}
+                    {% for person in site.people %}
+                      {% for person_group in person.groups %}
+                        {% if person_group[0] == group[0] %}
+                          {% comment %}Liquid templates do not have a logic not operator {% endcomment %}
+                          {% assign display_this = true %}
+                          {% if page.finished %}
+                          {% elsif person_group[1].finished %}
+                            {% assign display_this = false %}
+                          {% endif%}
+                          {% if display_this %}
+                            {% if person_on_top %}
+                              <p class="top group-member">
+                            {% else %}
+                              <p class="group-member">
                             {% endif %}
+                              <a href="{% include baseurl %}{{ person.url }}" class="hover-blue">{{ person.name }}</a>, {{ person.country }}{% if person_group[1].role %}, {{ person_group[1].role }}{% endif %}
+                            </p>
+                            {% assign person_on_top = false %}
                           {% endif %}
-                        {% endfor %}
+                        {% endif %}
                       {% endfor %}
-                    {% endif %}
-
+                    {% endfor %}
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
I have been informed that this is not an
acceptable solution - going back.