### PR TITLE
Enabled site-wide RSS feed

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -3,6 +3,7 @@ markdown_ext: "md"
 # https://help.github.com/articles/redirects-on-github-pages/
 plugins:
   - jekyll-redirect-from
+  - jekyll-feed
 
 # https://github.com/jekyll/jekyll/issues/302
 permalink: pretty

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -29,4 +29,6 @@
   <link href="{% include baseurl %}/assets/css/vue-cloaking.css" rel="stylesheet">
   <link href="{% include baseurl %}/assets/css/bootstrap-3.3.7.min.css" rel="stylesheet">
   <link href="{% include baseurl %}/assets/css/responsive.css" rel="stylesheet">
+
+  <link type="application/atom+xml" rel="alternate" href="{{ site.url }}{{ site.baseurl }}/feed/index.xml" title="NeIC web" />
 </head>


### PR DESCRIPTION
Using [jekyll-feed plugin](https://help.github.com/en/articles/atom-rss-feeds-for-github-pages) which is recommended by Github Pages.

Did not use the `{% feed_meta %}` tag in `_includes/head.html`, instead created the RSS `<link>` manually
because feed_meta always messed up the path to the xml file for some reason (have not confirmed
this, but likely due to other settings in _config.yml). Anyway, this way should be just as robust.

I have tested this on a freshly provisioned Ubuntu 18.04 box, with Ruby v2.5.1p57, Gem v2.7.6 and Jekyll v3.8.5 and everything works OK. The feed is generated, is auto-discoverable by Firefox, and links in the feed lead back to the right posts.