### PR TITLE
New NLCG member

### DIFF
--- a/_people/sebastian_von_alfthan.md
+++ b/_people/sebastian_von_alfthan.md
@@ -1,0 +1,15 @@
+---
+layout: master
+include: person
+name: Sebastian von Alfthan
+home: <a href="https://csc.fi">CSC</a>
+country: FI
+photo:
+email: sebastian.von.alfthan@csc.fi
+phone:
+on_contract: no
+has_been_on_contract: no
+groups:
+  nlcg:
+    role: Infrastructure
+---


### PR DESCRIPTION
Sebastian von Alfthan (CSC) replaces Jussi Heikonen (also CSC) as the Finland infrastructure representative at NLCG