### PR TITLE
Add coderefinery-team information

### DIFF
--- a/_activities/coderefinery.md
+++ b/_activities/coderefinery.md
@@ -44,6 +44,12 @@ groups:
     description: Management
     minutes: https://wiki.neic.no/int/CodeRefinery
     frequency: bi-Weekly
+  coderefinery-team: 
+    name: Team
+    description: https://coderefinery.org/about/partners/
+    minutes: https://github.com/coderefinery/meeting-minutes/blob/main/archive.md
+    frequency: weekly
+    
 ---
 
 CodeRefinery acts as a hub for FAIR (Findable, Accessible, Interoperable, and


### PR DESCRIPTION
Did not add each team member here on purpose as we have them all listen on our website, under partners as well as contributors for easier maintainability